### PR TITLE
Clean up powershell temp files after each execution to avoid running out of available filenames

### DIFF
--- a/Xpirit-Vsts-Build-InlineAzurePowershell/InlineAzurePowershell-Legacy.ps1
+++ b/Xpirit-Vsts-Build-InlineAzurePowershell/InlineAzurePowershell-Legacy.ps1
@@ -1,18 +1,18 @@
 Param(
-    [String] [Parameter(Mandatory = $true)] $ConnectedServiceNameSelector,    
+    [String] [Parameter(Mandatory = $true)] $ConnectedServiceNameSelector,
     [String] $ConnectedServiceName,
-    [String] $ConnectedServiceNameARM, 
+    [String] $ConnectedServiceNameARM,
     [string] $Script,
 	[string] $ScriptArguments
 )
 
-$scriptPath =  [System.IO.Path]::GetTempFileName().Replace(".tmp",".ps1")
+$scriptPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "$([System.Guid]::NewGuid().Guid).ps1"
 $script >> $scriptPath
 
 if (-not (get-command 'Import-VstsLocStrings'  -ErrorAction SilentlyContinue))
 {
     $parametershash = $PSBoundParameters
-    
+
     function Import-VstsLocStrings{
         Write-Output 'Import-VstsLocStrings'
     }
@@ -37,7 +37,7 @@ if (-not (get-command 'Import-VstsLocStrings'  -ErrorAction SilentlyContinue))
         [switch]$Require,
         [switch]$AsBool,
         [switch]$AsInt)
-        
+
         $result = $parametershash[$Name]
 
          # Write error if required.
@@ -132,5 +132,9 @@ $global:ErrorActionPreference = 'Continue'
         # Set the task result to failed if the object is an error record.
         if ($_ -is [System.Management.Automation.ErrorRecord]) {
             "##vso[task.complete result=Failed]"
+        }
+
+        if ([System.IO.File]::Exists($scriptPath)) {
+            [System.IO.File]::Delete($scriptPath)
         }
     }

--- a/Xpirit-Vsts-Build-InlineAzurePowershell/InlineAzurePowershell.ps1
+++ b/Xpirit-Vsts-Build-InlineAzurePowershell/InlineAzurePowershell.ps1
@@ -5,7 +5,7 @@ $script = Get-VstsInput -Name Script -Require
 $scriptArguments = Get-VstsInput -Name ScriptArguments
 
 
-$scriptPath =  [System.IO.Path]::GetTempFileName().Replace(".tmp",".ps1")
+$scriptPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "$([System.Guid]::NewGuid().Guid).ps1"
 $script >> $scriptPath
 
 if ($scriptArguments -match '[\r\n]') {
@@ -59,5 +59,9 @@ $global:ErrorActionPreference = 'Continue'
         # Set the task result to failed if the object is an error record.
         if ($_ -is [System.Management.Automation.ErrorRecord]) {
             "##vso[task.complete result=Failed]"
+        }
+
+        if ([System.IO.File]::Exists($scriptPath)) {
+            [System.IO.File]::Delete($scriptPath)
         }
     }

--- a/Xpirit-Vsts-Build-InlinePowershell/InlinePowershell-Legacy.ps1
+++ b/Xpirit-Vsts-Build-InlinePowershell/InlinePowershell-Legacy.ps1
@@ -5,14 +5,14 @@ Param(
 
 
 
-$scriptPath =  [System.IO.Path]::GetTempFileName().Replace(".tmp",".ps1")
+$scriptPath =  Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "$([System.Guid]::NewGuid().Guid).ps1"
 $script >> $scriptPath
 
 
 if (-not (get-command 'Import-VstsLocStrings'  -ErrorAction SilentlyContinue))
 {
     $parametershash = $PSBoundParameters
-    
+
     function Import-VstsLocStrings{
         Write-Output 'Import-VstsLocStrings'
     }
@@ -37,7 +37,7 @@ if (-not (get-command 'Import-VstsLocStrings'  -ErrorAction SilentlyContinue))
         [switch]$Require,
         [switch]$AsBool,
         [switch]$AsInt)
-        
+
         $result = $parametershash[$Name]
 
          # Write error if required.
@@ -98,7 +98,7 @@ Remove-Variable -Name scriptArguments
 Get-ChildItem -LiteralPath function: |
     Where-Object {
         ($_.ModuleName -eq 'VstsTaskSdk' -and $_.Name -ne 'Out-Default') -or
-        ($_.Name -eq 'Invoke-VstsTaskScript') 
+        ($_.Name -eq 'Invoke-VstsTaskScript')
     } |
     Remove-Item
 
@@ -130,5 +130,8 @@ $global:ErrorActionPreference = 'Continue'
         if ($_ -is [System.Management.Automation.ErrorRecord]) {
             "##vso[task.complete result=Failed]"
         }
+
+        if ([System.IO.File]::Exists($scriptPath)) {
+            [System.IO.File]::Delete($scriptPath)
+        }
     }
- 

--- a/Xpirit-Vsts-Build-InlinePowershell/InlinePowershell.ps1
+++ b/Xpirit-Vsts-Build-InlinePowershell/InlinePowershell.ps1
@@ -5,7 +5,7 @@ $script = Get-VstsInput -Name Script -Require
 $scriptArguments = Get-VstsInput -Name ScriptArguments
 
 
-$scriptPath =  [System.IO.Path]::GetTempFileName().Replace(".tmp",".ps1")
+$scriptPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "$([System.Guid]::NewGuid().Guid).ps1"
 $script >> $scriptPath
 
 if ($scriptArguments -match '[\r\n]') {
@@ -22,7 +22,7 @@ Remove-Variable -Name scriptArguments
 Get-ChildItem -LiteralPath function: |
     Where-Object {
         ($_.ModuleName -eq 'VstsTaskSdk' -and $_.Name -ne 'Out-Default') -or
-        ($_.Name -eq 'Invoke-VstsTaskScript') 
+        ($_.Name -eq 'Invoke-VstsTaskScript')
     } |
     Remove-Item
 
@@ -53,5 +53,9 @@ $global:ErrorActionPreference = 'Continue'
         # Set the task result to failed if the object is an error record.
         if ($_ -is [System.Management.Automation.ErrorRecord]) {
             "##vso[task.complete result=Failed]"
+        }
+
+        if ([System.IO.File]::Exists($scriptPath)) {
+            [System.IO.File]::Delete($scriptPath)
         }
     }

--- a/Xpirit-Vsts-Build-InlinePowershell/task.json
+++ b/Xpirit-Vsts-Build-InlinePowershell/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [ ],
   "minimumAgentVersion": "1.95.0",


### PR DESCRIPTION
This change replaces [System.IO.Path]::GetTempFileName() with a combination of [System.IO.Path]::GetTempPath and guid.

After invoking the inline powershell temp file, utilize [System.IO.Path]::Delete only after it's been confirmed to exist.